### PR TITLE
Omit test- and config files from test coverage

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,10 @@
 ENV["RAILS_ENV"] ||= "test"
 
 require "simplecov"
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec/"
+  add_filter "/config/"
+end
 
 require File.expand_path("../../config/environment", __FILE__)
 


### PR DESCRIPTION
It doesn't make much sense to track coverage of test- and configuration files, so let's just omit them from coverage reporting.

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] Your PR relates to one subject.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

