### PR TITLE
Add notification that we'll authorize through GitHub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem "puma", "~> 3.0"
 gem "sass-rails"
 gem "bootstrap-sass"
 
+gem "font-awesome-rails"
+
 gem "uglifier"
 gem "jquery-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    font-awesome-rails (4.7.0.0)
+      railties (>= 3.2, < 5.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashie (3.4.6)
@@ -216,6 +218,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   dotenv-rails
   factory_girl_rails
+  font-awesome-rails
   jquery-rails
   omniauth
   omniauth-github

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -1,5 +1,6 @@
 @import "bootstrap-sprockets"
 @import "bootstrap"
+@import "font-awesome"
 @import "overrides"
 @import "typography"
 

--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -7,3 +7,9 @@ label + small
 
 textarea.form-control
   height: 200px
+
+.btn > .fa
+  margin-right: 8px
+
+.btn-subtitle
+  margin-top: 8px

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -9,7 +9,12 @@
         <span>Singapore</span>
       </div>
 
-      <%= link_to "Submit a Paper", new_my_paper_path, class: "btn btn-lg btn-success" %>
+      <%= link_to new_my_paper_path, class: "btn btn-lg btn-success" do %>
+        <%= fa_icon "github" %>
+        Submit a Paper
+      <% end %>
+
+      <p class="btn-subtitle">(We'll ask you to authorize through GitHub.)</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This change adds an Octocat to the button, and a small notice underneath to warn the user we'll initiate a GitHub auth.

<img width="521" alt="screen shot 2016-12-20 at 15 07 34" src="https://cloud.githubusercontent.com/assets/5259935/21341246/810fa784-c6c6-11e6-9f3c-51b7611ef248.png">

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.

---

**If your change contains views, ensure that:**

 - [X] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
