### PR TITLE
Add CFP submission information to the landing page

### DIFF
--- a/app/assets/stylesheets/landing_page.sass
+++ b/app/assets/stylesheets/landing_page.sass
@@ -1,6 +1,3 @@
-.container.full-page
-  padding-top: 100px
-
 .logo
   width: 400px
 
@@ -9,3 +6,6 @@
   > span
     display: block
     font-size: 1.75em
+
+.bg-alt
+  background-color: #f0f0f0

--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -13,3 +13,18 @@ textarea.form-control
 
 .btn-subtitle
   margin-top: 8px
+
+.container-padded
+  padding-bottom: 50px
+  padding-top: 50px
+
+ol, ul
+  li
+    padding: 2px 0
+
+.panel
+  ol, ul
+    padding-left: 24px
+
+    li
+      padding: 0

--- a/app/assets/stylesheets/typography.sass
+++ b/app/assets/stylesheets/typography.sass
@@ -1,2 +1,5 @@
 *
   font-family: "Raleway", Helvetica, sans-serif
+
+h2
+  margin-bottom: 20px

--- a/app/views/my/papers/new.html.erb
+++ b/app/views/my/papers/new.html.erb
@@ -55,19 +55,21 @@
                 <li>Paper and actual talk must be in English.</li>
                 <li>Paper must have a title and an abstract of around 100 words.</li>
                 <li>Paper must be submitted before 2017-03-15 23:59:59 UTC.</li>
+                <li>Paper contents must adhere to our <%= link_to "Code of Conduct", "http://www.reddotrubyconf.com/code-of-conduct#content" %>.</li>
               </ul>
             </p>
           </div>
         </div>
 
         <div class="panel panel-default">
-          <div class="panel-heading">Submission Policies</div>
+          <div class="panel-heading">Submission Policy</div>
           <div class="panel-body">
             <p>
               <ul>
                 <li>You can submit any number of papers.</li>
                 <li>We accept talks that have been given before at other conferences.</li>
                 <li>You will retain copyright to your talk and any supporting materials.</li>
+                <li>All talks will be recorded and made available online, free of charge, after the conference.</li>
               </ul>
             </p>
           </div>
@@ -80,6 +82,18 @@
               <ul>
                 <li>Reviews are double blind. We take into account novelty, depth, practical impact, and presentation.</li>
                 <li>Final selection is done by the organizing committee.</li>
+              </ul>
+            </p>
+          </div>
+        </div>
+
+        <div class="panel panel-default">
+          <div class="panel-heading">Reimbursement</div>
+          <div class="panel-body">
+            <p>
+              <ul>
+                <li>Selected speakers will recieve free admission to the conference.</li>
+                <li>We will reserve one ticket at super early bird price for speakers who aren't selected.</li>
               </ul>
             </p>
           </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,4 @@
-<div class="container full-page">
+<div class="container container-padded">
   <div class="row">
     <div class="col-xs-12 text-center">
       <%= image_tag "logo-vertical.png", class: "logo" %>
@@ -15,6 +15,56 @@
       <% end %>
 
       <p class="btn-subtitle">(We'll ask you to authorize through GitHub.)</p>
+    </div>
+  </div>
+</div>
+
+<div class="container-fluid container-padded bg-alt">
+  <div class="row">
+    <div class="col-xs-12 col-sm-6 col-sm-offset-3">
+      <h2>Requirements</h2>
+
+      <ul>
+        <li>Paper and actual talk must be in English.</li>
+        <li>Paper must have a title and an abstract of around 100 words.</li>
+        <li>Paper must be submitted before 2017-03-15 23:59:59 UTC.</li>
+        <li>Paper contents must adhere to our <%= link_to "Code of Conduct", "http://www.reddotrubyconf.com/code-of-conduct#content" %>.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12 col-sm-6 col-sm-offset-3">
+      <h2>Submission Policy</h2>
+
+      <ul>
+        <li>You can submit any number of papers.</li>
+        <li>We accept talks that have been given before at other conferences.</li>
+        <li>You will retain copyright to your talk and any supporting materials.</li>
+        <li>All talks will be recorded and made available online, free of charge, after the conference.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12 col-sm-6 col-sm-offset-3">
+      <h2>Review &amp; Selection Process</h2>
+
+      <ul>
+        <li>Reviews are double blind. We take into account novelty, depth, practical impact, and presentation.</li>
+        <li>Final selection is done by the organizing committee.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12 col-sm-6 col-sm-offset-3">
+      <h2>Reimbursement</h2>
+
+      <ul>
+        <li>Selected speakers will recieve free admission to the conference.</li>
+        <li>We will reserve one ticket at super early bird price for speakers who aren't selected.</li>
+      </ul>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This change lifts all the information available when submitting a paper and also makes it available on the landing page.

<img width="823" alt="screen shot 2016-12-20 at 17 33 00" src="https://cloud.githubusercontent.com/assets/5259935/21345243/6933020a-c6da-11e6-91da-36560c75601a.png">

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.

---

**If your change contains views, ensure that:**

 - [X] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
