### PR TITLE
[Fix #29] Display contents of submitted items with line breaks

### DIFF
--- a/app/views/my/papers/show.html.erb
+++ b/app/views/my/papers/show.html.erb
@@ -7,10 +7,10 @@
       <span class="label label-primary"><%= @paper.speaker_slot %></span>
 
       <h2>Abstract</h2>
-      <p><%= @paper.abstract %></p>
+      <p><%= simple_format @paper.abstract %></p>
 
       <h2>Outline</h2>
-      <p><%= @paper.outline %></p>
+      <p><%= simple_format @paper.outline %></p>
 
       <div class="text-right">
         <% if @paper.editable? %>


### PR DESCRIPTION
This PR is in reference to #29.

I have used the simple_format helper in the frontend to display the text with line breaks.