### PR TITLE
Add timestamps to users and papers

### DIFF
--- a/db/migrate/20170111054908_add_timestamps_to_users.rb
+++ b/db/migrate/20170111054908_add_timestamps_to_users.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :created_at, :datetime
+    add_column :users, :updated_at, :datetime
+  end
+end

--- a/db/migrate/20170111055111_add_timestamps_to_papers.rb
+++ b/db/migrate/20170111055111_add_timestamps_to_papers.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToPapers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :papers, :created_at, :datetime
+    add_column :papers, :updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,26 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161205095042) do
+ActiveRecord::Schema.define(version: 20170111055111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "papers", force: :cascade do |t|
-    t.string  "title",                    null: false
-    t.text    "abstract",                 null: false
-    t.integer "status",       default: 1, null: false
-    t.integer "user_id"
-    t.integer "speaker_slot", default: 1, null: false
-    t.text    "outline"
+    t.string   "title",                    null: false
+    t.text     "abstract",                 null: false
+    t.integer  "status",       default: 1, null: false
+    t.integer  "user_id"
+    t.integer  "speaker_slot", default: 1, null: false
+    t.text     "outline"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["user_id"], name: "index_papers_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name",       null: false
-    t.string "email",      null: false
-    t.text   "bio"
-    t.string "avatar_url"
+    t.string   "name",       null: false
+    t.string   "email",      null: false
+    t.text     "bio"
+    t.string   "avatar_url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_foreign_key "papers", "users"


### PR DESCRIPTION
In a gross oversight, the default timestamp columns weren't added to the `User` and `Paper` models. This change fixes that.

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.

---

**If your change contains models, ensure that:**

 - [X] You have checked in the new `schema.rb` after migrating.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
