### PR TITLE
Send a weekly CFP update to Slack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem "turbolinks"
 gem "omniauth"
 gem "omniauth-github"
 
+gem "httparty"
+
 group :test do
   gem "rspec-rails"
   gem "factory_girl_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashie (3.4.6)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
@@ -219,6 +221,7 @@ DEPENDENCIES
   dotenv-rails
   factory_girl_rails
   font-awesome-rails
+  httparty
   jquery-rails
   omniauth
   omniauth-github
@@ -240,4 +243,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/lib/tasks/slack.rake
+++ b/lib/tasks/slack.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "httparty"
+require "json"
+
+TODAY = Date.current.freeze
+WEBHOOK = ENV["SLACK_WEBHOOK_URL"].freeze
+HEADERS = { "Content-Type" => "application/json" }.freeze
+
+namespace :slack do
+  desc "Send an update about the CFP status"
+  task send_cfp_status_update: :environment do
+    MESSAGE = "We had %d new CFP submissions in the last week, for a total of %d.".freeze
+
+    # Heroku Scheduler can only run on a daily interval, but we want a weekly
+    # report, so do nothing for the other days.
+    next unless TODAY.tuesday?
+
+    new_submission_period = (TODAY - 1.week).upto(TODAY)
+
+    new_submissions = Paper.submitted.where(updated_at: new_submission_period.to_a).count
+    all_submissions = Paper.submitted.count
+
+    message = format(MESSAGE, new_submissions, all_submissions)
+
+    HTTParty.post(WEBHOOK, body: { text: message }.to_json, headers: HEADERS)
+  end
+end


### PR DESCRIPTION
This change adds a weekly Slack notification, highlighting how many new CFP proposals have been sent in the last seven days, and the total all in all.

The rake task is intended to be run with Heroku Scheduler.

(Some of this logic could be factored into its own class(es) and tested in isolation if anyone has the time and energy. 😀 )

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.
 - [X] If it relates to a GitHub issue, you have prefixed the title with `[Fix #n]`.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
